### PR TITLE
Added iPad6,7 to the device names by code dictionary to properly iden…

### DIFF
--- a/SDVersion/SDiOSVersion/SDiOSVersion.m
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.m
@@ -64,6 +64,7 @@
                               @"iPad5,2" :[NSNumber numberWithInteger:iPadMini4],
                               @"iPad5,3" :[NSNumber numberWithInteger:iPadAir2],
                               @"iPad5,4" :[NSNumber numberWithInteger:iPadAir2],
+                              @"iPad6,7" :[NSNumber numberWithInteger:iPadPro],                              
                               @"iPad6,8" :[NSNumber numberWithInteger:iPadPro],
                               
                               //iPods


### PR DESCRIPTION
…tifiy iPad Pro

The iPad Pro (Wifi EU) model is reported as iPad6,7 so this has been added to list of iPad Pro devices