### PR TITLE
Add availability macros for iOS, watchOS, and tvOS

### DIFF
--- a/SDVersion-Demo/SDVersion/SDiOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDiOSVersion.h
@@ -10,42 +10,50 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
-typedef NS_ENUM(NSInteger, DeviceVersion){
-    iPhone4           = 3,
-    iPhone4S          = 4,
-    iPhone5           = 5,
-    iPhone5C          = 6,
-    iPhone5S          = 7,
-    iPhone6           = 8,
-    iPhone6Plus       = 9,
-    iPhone6S          = 10,
-    iPhone6SPlus      = 11,
-    iPhoneSE          = 12,
+typedef NS_ENUM(NSInteger, DeviceVersion) {
+    iPhone            NS_ENUM_DEPRECATED_IOS(1.0, 4.0)  =  0,
+    iPhone3G          NS_ENUM_DEPRECATED_IOS(2.0, 5.0)  =  1,
+    iPhone3GS         NS_ENUM_DEPRECATED_IOS(3.0, 7.0)  =  2,
+    iPhone4           NS_ENUM_DEPRECATED_IOS(4.0, 8.0)  =  3,
+    iPhone4S          NS_ENUM_DEPRECATED_IOS(5.0, 10.0) =  4,
+    iPhone5           NS_ENUM_AVAILABLE_IOS(6.0)        =  5,
+    iPhone5C          NS_ENUM_AVAILABLE_IOS(7.0)        =  6,
+    iPhone5S          NS_ENUM_AVAILABLE_IOS(7.0)        =  7,
+    iPhone6           NS_ENUM_AVAILABLE_IOS(8.0)        =  8,
+    iPhone6Plus       NS_ENUM_AVAILABLE_IOS(8.0)        =  9,
+    iPhone6S          NS_ENUM_AVAILABLE_IOS(9.0)        = 10,
+    iPhone6SPlus      NS_ENUM_AVAILABLE_IOS(9.0)        = 11,
+    iPhoneSE          NS_ENUM_AVAILABLE_IOS(9.3)        = 12,
     
-    iPad1             = 13,
-    iPad2             = 14,
-    iPadMini          = 15,
-    iPad3             = 16,
-    iPad4             = 17,
-    iPadAir           = 18,
-    iPadMini2         = 19,
-    iPadAir2          = 20,
-    iPadMini3         = 21,
-    iPadMini4         = 22,
-    iPadPro12Dot9Inch = 23,
-    iPadPro9Dot7Inch  = 24,
+    iPad1             NS_ENUM_DEPRECATED_IOS(3.2, 6.0)  = 13,
+    iPad2             NS_ENUM_DEPRECATED_IOS(4.3, 10.0) = 14,
+    iPadMini          NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 15,
+    iPad3             NS_ENUM_DEPRECATED_IOS(5.1, 10.0) = 16,
+    iPad4             NS_ENUM_AVAILABLE_IOS(6.0)        = 17,
+    iPadAir           NS_ENUM_AVAILABLE_IOS(7.0)        = 18,
+    iPadMini2         NS_ENUM_AVAILABLE_IOS(7.0)        = 19,
+    iPadAir2          NS_ENUM_AVAILABLE_IOS(8.1)        = 20,
+    iPadMini3         NS_ENUM_AVAILABLE_IOS(8.1)        = 21,
+    iPadMini4         NS_ENUM_AVAILABLE_IOS(9.0)        = 22,
+    iPadPro12Dot9Inch NS_ENUM_AVAILABLE_IOS(9.1)        = 23,
+    iPadPro9Dot7Inch  NS_ENUM_AVAILABLE_IOS(9.3)        = 24,
     
-    iPodTouch1Gen     = 25,
-    iPodTouch2Gen     = 26,
-    iPodTouch3Gen     = 27,
-    iPodTouch4Gen     = 28,
-    iPodTouch5Gen     = 29,
-    iPodTouch6Gen     = 30,
+    iPodTouch1Gen     NS_ENUM_DEPRECATED_IOS(1.1, 4.0)  = 25,
+    iPodTouch2Gen     NS_ENUM_DEPRECATED_IOS(2.1, 5.0)  = 26,
+    iPodTouch3Gen     NS_ENUM_DEPRECATED_IOS(3.1, 6.0)  = 27,
+    iPodTouch4Gen     NS_ENUM_DEPRECATED_IOS(4.1, 7.0)  = 28,
+    iPodTouch5Gen     NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 29,
+    iPodTouch6Gen     NS_ENUM_AVAILABLE_IOS(8.4)        = 30,
     
-    Simulator         =  0
+    Simulator                                           = 31,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
+    [iPhone]            = @"iPhone",
+    [iPhone3G]          = @"iPhone 3G",
+    [iPhone3GS]         = @"iPhone 3GS",
     [iPhone4]           = @"iPhone 4",
     [iPhone4S]          = @"iPhone 4S",
     [iPhone5]           = @"iPhone 5",
@@ -79,22 +87,26 @@ static NSString *DeviceVersionNames[] = {
     
     [Simulator]         = @"Simulator"
 };
+#pragma clang diagnostic pop
 
-typedef NS_ENUM(NSInteger, DeviceSize){
-    UnknownSize     = 0,
-    Screen3Dot5inch = 1,
-    Screen4inch     = 2,
-    Screen4Dot7inch = 3,
-    Screen5Dot5inch = 4
+typedef NS_ENUM(NSInteger, DeviceSize) {
+    UnknownSize                                       = 0,
+    Screen3Dot5inch NS_ENUM_DEPRECATED_IOS(1.0, 10.0) = 1,
+    Screen4inch     NS_ENUM_AVAILABLE_IOS(6.0)        = 2,
+    Screen4Dot7inch NS_ENUM_AVAILABLE_IOS(8.0)        = 3,
+    Screen5Dot5inch NS_ENUM_AVAILABLE_IOS(8.0)        = 4,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceSizeNames[] = {
     [UnknownSize]     = @"Unknown Size",
     [Screen3Dot5inch] = @"3.5 inch",
     [Screen4inch]     = @"4 inch",
     [Screen4Dot7inch] = @"4.7 inch",
-    [Screen5Dot5inch] = @"5.5 inch"
+    [Screen5Dot5inch] = @"5.5 inch",
 };
+#pragma clang diagnostic pop
 
 @interface SDiOSVersion : NSObject
 

--- a/SDVersion-Demo/SDVersion/SDtvOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDtvOSVersion.h
@@ -11,8 +11,9 @@
 #import <sys/utsname.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleTV4          = 1,
-    Simulator         = 0
+    AppleTV4  NS_ENUM_AVAILABLE_IOS(9.0) = 1,
+    
+    Simulator                            = 0
 };
 
 static NSString *DeviceVersionNames[] = {

--- a/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
@@ -9,27 +9,30 @@
 #import <WatchKit/WatchKit.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleWatch38mm = 1,
-    AppleWatch42mm = 2,
-    Simulator      = 0
+    
+    AppleWatch38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
+    AppleWatch42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
+    
+    Simulator      = 0,
 };
 
 static NSString *DeviceVersionNames[] = {
     [AppleWatch38mm] = @"Apple Watch 38mm",
     [AppleWatch42mm] = @"Apple Watch 42mm",
-    [Simulator]      = @"Simulator"
+    [Simulator]      = @"Simulator",
 };
 
-typedef NS_ENUM(NSInteger, DeviceSize){
+typedef NS_ENUM(NSInteger, DeviceSize) {
     UnknownSize = 0,
-    Screen38mm  = 1,
-    Screen42mm  = 2
+    
+    Screen38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
+    Screen42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
 };
 
 static NSString *DeviceSizeNames[] = {
     [UnknownSize] = @"Unknown Size",
     [Screen38mm]  = @"38mm",
-    [Screen42mm]  = @"42mm"
+    [Screen42mm]  = @"42mm",
 };
 
 @interface SDwatchOSVersion : NSObject


### PR DESCRIPTION
This PR uses the `NS_ENUM_AVAILABLE_IOS` and `NS_ENUM_DEPRECATED_IOS` macros to add availability information to device enums. By doing this, we can get better warnings when trying to run device-specific code on OS versions that they don’t support. For instance, in this screenshot, I’ve set the deployment target of the SDiOSVersion sample app to iOS 10.0, meaning that the iPhone 4S and 3.5" screen can’t be running this code:
![screen shot 2016-08-19 at 10 47 31 am](https://cloud.githubusercontent.com/assets/147458/17813717/6c67abec-65fa-11e6-8d93-365af08a88d9.png)

I’ve gone through and added the historical deprecation information for every model of iOS device. The Swift compiler is smart enough to not even bring old devices over that can’t run a version of Swift. Speaking of Swift, this also generates `@available` lines in the generated interface. Here’s the updated list of iOS devices in Objective-C:

```Objective-C
typedef NS_ENUM(NSInteger, DeviceVersion) {
    iPhone            NS_ENUM_DEPRECATED_IOS(1.0, 4.0)  =  0,
    iPhone3G          NS_ENUM_DEPRECATED_IOS(2.0, 5.0)  =  1,
    iPhone3GS         NS_ENUM_DEPRECATED_IOS(3.0, 7.0)  =  2,
    iPhone4           NS_ENUM_DEPRECATED_IOS(4.0, 8.0)  =  3,
    iPhone4S          NS_ENUM_DEPRECATED_IOS(5.0, 10.0) =  4,
    iPhone5           NS_ENUM_AVAILABLE_IOS(6.0)        =  5,
    iPhone5C          NS_ENUM_AVAILABLE_IOS(7.0)        =  6,
    iPhone5S          NS_ENUM_AVAILABLE_IOS(7.0)        =  7,
    iPhone6           NS_ENUM_AVAILABLE_IOS(8.0)        =  8,
    iPhone6Plus       NS_ENUM_AVAILABLE_IOS(8.0)        =  9,
    iPhone6S          NS_ENUM_AVAILABLE_IOS(9.0)        = 10,
    iPhone6SPlus      NS_ENUM_AVAILABLE_IOS(9.0)        = 11,
    iPhoneSE          NS_ENUM_AVAILABLE_IOS(9.3)        = 12,
    
    iPad1             NS_ENUM_DEPRECATED_IOS(3.2, 6.0)  = 13,
    iPad2             NS_ENUM_DEPRECATED_IOS(4.3, 10.0) = 14,
    iPadMini          NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 15,
    iPad3             NS_ENUM_DEPRECATED_IOS(5.1, 10.0) = 16,
    iPad4             NS_ENUM_AVAILABLE_IOS(6.0)        = 17,
    iPadAir           NS_ENUM_AVAILABLE_IOS(7.0)        = 18,
    iPadMini2         NS_ENUM_AVAILABLE_IOS(7.0)        = 19,
    iPadAir2          NS_ENUM_AVAILABLE_IOS(8.1)        = 20,
    iPadMini3         NS_ENUM_AVAILABLE_IOS(8.1)        = 21,
    iPadMini4         NS_ENUM_AVAILABLE_IOS(9.0)        = 22,
    iPadPro12Dot9Inch NS_ENUM_AVAILABLE_IOS(9.1)        = 23,
    iPadPro9Dot7Inch  NS_ENUM_AVAILABLE_IOS(9.3)        = 24,
    
    iPodTouch1Gen     NS_ENUM_DEPRECATED_IOS(1.1, 4.0)  = 25,
    iPodTouch2Gen     NS_ENUM_DEPRECATED_IOS(2.1, 5.0)  = 26,
    iPodTouch3Gen     NS_ENUM_DEPRECATED_IOS(3.1, 6.0)  = 27,
    iPodTouch4Gen     NS_ENUM_DEPRECATED_IOS(4.1, 7.0)  = 28,
    iPodTouch5Gen     NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 29,
    iPodTouch6Gen     NS_ENUM_AVAILABLE_IOS(8.4)        = 30,
    
    Simulator                                           = 31,
};
```
and here’s the generated version in Swift:
```Swift
public enum DeviceVersion : Int {

    
    @available(iOS, introduced: 4.0, deprecated: 8.0)
    case iPhone4

    @available(iOS, introduced: 5.0, deprecated: 10.0)
    case iPhone4S

    @available(iOS 6.0, *)
    case iPhone5

    @available(iOS 7.0, *)
    case iPhone5C

    @available(iOS 7.0, *)
    case iPhone5S

    @available(iOS 8.0, *)
    case iPhone6

    @available(iOS 8.0, *)
    case iPhone6Plus

    @available(iOS 9.0, *)
    case iPhone6S

    @available(iOS 9.0, *)
    case iPhone6SPlus

    @available(iOS 9.3, *)
    case iPhoneSE

    
    @available(iOS, introduced: 4.3, deprecated: 10.0)
    case iPad2

    @available(iOS, introduced: 6.0, deprecated: 10.0)
    case iPadMini

    @available(iOS, introduced: 5.1, deprecated: 10.0)
    case iPad3

    @available(iOS 6.0, *)
    case iPad4

    @available(iOS 7.0, *)
    case iPadAir

    @available(iOS 7.0, *)
    case iPadMini2

    @available(iOS 8.1, *)
    case iPadAir2

    @available(iOS 8.1, *)
    case iPadMini3

    @available(iOS 9.0, *)
    case iPadMini4

    @available(iOS 9.1, *)
    case iPadPro12Dot9Inch

    @available(iOS 9.3, *)
    case iPadPro9Dot7Inch

    
    @available(iOS, introduced: 6.0, deprecated: 10.0)
    case iPodTouch5Gen

    @available(iOS 8.4, *)
    case iPodTouch6Gen

    
    case Simulator
}
```
As new devices and screen sizes become available, keeping SDVersion up to date with the deprecation information will allow developers writing device-specific code to automatically remove dead code as they update their minimum deployment target.