### PR TITLE
Revert "Add availability macros for iOS, watchOS, and tvOS"

### DIFF
--- a/SDVersion-Demo/SDVersion/SDiOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDiOSVersion.h
@@ -10,50 +10,42 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
-typedef NS_ENUM(NSInteger, DeviceVersion) {
-    iPhone            NS_ENUM_DEPRECATED_IOS(1.0, 4.0)  =  0,
-    iPhone3G          NS_ENUM_DEPRECATED_IOS(2.0, 5.0)  =  1,
-    iPhone3GS         NS_ENUM_DEPRECATED_IOS(3.0, 7.0)  =  2,
-    iPhone4           NS_ENUM_DEPRECATED_IOS(4.0, 8.0)  =  3,
-    iPhone4S          NS_ENUM_DEPRECATED_IOS(5.0, 10.0) =  4,
-    iPhone5           NS_ENUM_AVAILABLE_IOS(6.0)        =  5,
-    iPhone5C          NS_ENUM_AVAILABLE_IOS(7.0)        =  6,
-    iPhone5S          NS_ENUM_AVAILABLE_IOS(7.0)        =  7,
-    iPhone6           NS_ENUM_AVAILABLE_IOS(8.0)        =  8,
-    iPhone6Plus       NS_ENUM_AVAILABLE_IOS(8.0)        =  9,
-    iPhone6S          NS_ENUM_AVAILABLE_IOS(9.0)        = 10,
-    iPhone6SPlus      NS_ENUM_AVAILABLE_IOS(9.0)        = 11,
-    iPhoneSE          NS_ENUM_AVAILABLE_IOS(9.3)        = 12,
+typedef NS_ENUM(NSInteger, DeviceVersion){
+    iPhone4           = 3,
+    iPhone4S          = 4,
+    iPhone5           = 5,
+    iPhone5C          = 6,
+    iPhone5S          = 7,
+    iPhone6           = 8,
+    iPhone6Plus       = 9,
+    iPhone6S          = 10,
+    iPhone6SPlus      = 11,
+    iPhoneSE          = 12,
     
-    iPad1             NS_ENUM_DEPRECATED_IOS(3.2, 6.0)  = 13,
-    iPad2             NS_ENUM_DEPRECATED_IOS(4.3, 10.0) = 14,
-    iPadMini          NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 15,
-    iPad3             NS_ENUM_DEPRECATED_IOS(5.1, 10.0) = 16,
-    iPad4             NS_ENUM_AVAILABLE_IOS(6.0)        = 17,
-    iPadAir           NS_ENUM_AVAILABLE_IOS(7.0)        = 18,
-    iPadMini2         NS_ENUM_AVAILABLE_IOS(7.0)        = 19,
-    iPadAir2          NS_ENUM_AVAILABLE_IOS(8.1)        = 20,
-    iPadMini3         NS_ENUM_AVAILABLE_IOS(8.1)        = 21,
-    iPadMini4         NS_ENUM_AVAILABLE_IOS(9.0)        = 22,
-    iPadPro12Dot9Inch NS_ENUM_AVAILABLE_IOS(9.1)        = 23,
-    iPadPro9Dot7Inch  NS_ENUM_AVAILABLE_IOS(9.3)        = 24,
+    iPad1             = 13,
+    iPad2             = 14,
+    iPadMini          = 15,
+    iPad3             = 16,
+    iPad4             = 17,
+    iPadAir           = 18,
+    iPadMini2         = 19,
+    iPadAir2          = 20,
+    iPadMini3         = 21,
+    iPadMini4         = 22,
+    iPadPro12Dot9Inch = 23,
+    iPadPro9Dot7Inch  = 24,
     
-    iPodTouch1Gen     NS_ENUM_DEPRECATED_IOS(1.1, 4.0)  = 25,
-    iPodTouch2Gen     NS_ENUM_DEPRECATED_IOS(2.1, 5.0)  = 26,
-    iPodTouch3Gen     NS_ENUM_DEPRECATED_IOS(3.1, 6.0)  = 27,
-    iPodTouch4Gen     NS_ENUM_DEPRECATED_IOS(4.1, 7.0)  = 28,
-    iPodTouch5Gen     NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 29,
-    iPodTouch6Gen     NS_ENUM_AVAILABLE_IOS(8.4)        = 30,
+    iPodTouch1Gen     = 25,
+    iPodTouch2Gen     = 26,
+    iPodTouch3Gen     = 27,
+    iPodTouch4Gen     = 28,
+    iPodTouch5Gen     = 29,
+    iPodTouch6Gen     = 30,
     
-    Simulator                                           = 31,
+    Simulator         =  0
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
-    [iPhone]            = @"iPhone",
-    [iPhone3G]          = @"iPhone 3G",
-    [iPhone3GS]         = @"iPhone 3GS",
     [iPhone4]           = @"iPhone 4",
     [iPhone4S]          = @"iPhone 4S",
     [iPhone5]           = @"iPhone 5",
@@ -87,26 +79,22 @@ static NSString *DeviceVersionNames[] = {
     
     [Simulator]         = @"Simulator"
 };
-#pragma clang diagnostic pop
 
-typedef NS_ENUM(NSInteger, DeviceSize) {
-    UnknownSize                                       = 0,
-    Screen3Dot5inch NS_ENUM_DEPRECATED_IOS(1.0, 10.0) = 1,
-    Screen4inch     NS_ENUM_AVAILABLE_IOS(6.0)        = 2,
-    Screen4Dot7inch NS_ENUM_AVAILABLE_IOS(8.0)        = 3,
-    Screen5Dot5inch NS_ENUM_AVAILABLE_IOS(8.0)        = 4,
+typedef NS_ENUM(NSInteger, DeviceSize){
+    UnknownSize     = 0,
+    Screen3Dot5inch = 1,
+    Screen4inch     = 2,
+    Screen4Dot7inch = 3,
+    Screen5Dot5inch = 4
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceSizeNames[] = {
     [UnknownSize]     = @"Unknown Size",
     [Screen3Dot5inch] = @"3.5 inch",
     [Screen4inch]     = @"4 inch",
     [Screen4Dot7inch] = @"4.7 inch",
-    [Screen5Dot5inch] = @"5.5 inch",
+    [Screen5Dot5inch] = @"5.5 inch"
 };
-#pragma clang diagnostic pop
 
 @interface SDiOSVersion : NSObject
 

--- a/SDVersion-Demo/SDVersion/SDtvOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDtvOSVersion.h
@@ -11,9 +11,8 @@
 #import <sys/utsname.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleTV4  NS_ENUM_AVAILABLE_IOS(9.0) = 1,
-    
-    Simulator                            = 0
+    AppleTV4          = 1,
+    Simulator         = 0
 };
 
 static NSString *DeviceVersionNames[] = {

--- a/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
@@ -9,30 +9,27 @@
 #import <WatchKit/WatchKit.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    
-    AppleWatch38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
-    AppleWatch42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
-    
-    Simulator      = 0,
+    AppleWatch38mm = 1,
+    AppleWatch42mm = 2,
+    Simulator      = 0
 };
 
 static NSString *DeviceVersionNames[] = {
     [AppleWatch38mm] = @"Apple Watch 38mm",
     [AppleWatch42mm] = @"Apple Watch 42mm",
-    [Simulator]      = @"Simulator",
+    [Simulator]      = @"Simulator"
 };
 
-typedef NS_ENUM(NSInteger, DeviceSize) {
+typedef NS_ENUM(NSInteger, DeviceSize){
     UnknownSize = 0,
-    
-    Screen38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
-    Screen42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
+    Screen38mm  = 1,
+    Screen42mm  = 2
 };
 
 static NSString *DeviceSizeNames[] = {
     [UnknownSize] = @"Unknown Size",
     [Screen38mm]  = @"38mm",
-    [Screen42mm]  = @"42mm",
+    [Screen42mm]  = @"42mm"
 };
 
 @interface SDwatchOSVersion : NSObject

--- a/SDVersion/SDiOSVersion/SDiOSVersion.h
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.h
@@ -10,50 +10,42 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
-typedef NS_ENUM(NSInteger, DeviceVersion) {
-    iPhone            NS_ENUM_DEPRECATED_IOS(1.0, 4.0)  =  0,
-    iPhone3G          NS_ENUM_DEPRECATED_IOS(2.0, 5.0)  =  1,
-    iPhone3GS         NS_ENUM_DEPRECATED_IOS(3.0, 7.0)  =  2,
-    iPhone4           NS_ENUM_DEPRECATED_IOS(4.0, 8.0)  =  3,
-    iPhone4S          NS_ENUM_DEPRECATED_IOS(5.0, 10.0) =  4,
-    iPhone5           NS_ENUM_AVAILABLE_IOS(6.0)        =  5,
-    iPhone5C          NS_ENUM_AVAILABLE_IOS(7.0)        =  6,
-    iPhone5S          NS_ENUM_AVAILABLE_IOS(7.0)        =  7,
-    iPhone6           NS_ENUM_AVAILABLE_IOS(8.0)        =  8,
-    iPhone6Plus       NS_ENUM_AVAILABLE_IOS(8.0)        =  9,
-    iPhone6S          NS_ENUM_AVAILABLE_IOS(9.0)        = 10,
-    iPhone6SPlus      NS_ENUM_AVAILABLE_IOS(9.0)        = 11,
-    iPhoneSE          NS_ENUM_AVAILABLE_IOS(9.3)        = 12,
+typedef NS_ENUM(NSInteger, DeviceVersion){
+    iPhone4           = 3,
+    iPhone4S          = 4,
+    iPhone5           = 5,
+    iPhone5C          = 6,
+    iPhone5S          = 7,
+    iPhone6           = 8,
+    iPhone6Plus       = 9,
+    iPhone6S          = 10,
+    iPhone6SPlus      = 11,
+    iPhoneSE          = 12,
     
-    iPad1             NS_ENUM_DEPRECATED_IOS(3.2, 6.0)  = 13,
-    iPad2             NS_ENUM_DEPRECATED_IOS(4.3, 10.0) = 14,
-    iPadMini          NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 15,
-    iPad3             NS_ENUM_DEPRECATED_IOS(5.1, 10.0) = 16,
-    iPad4             NS_ENUM_AVAILABLE_IOS(6.0)        = 17,
-    iPadAir           NS_ENUM_AVAILABLE_IOS(7.0)        = 18,
-    iPadMini2         NS_ENUM_AVAILABLE_IOS(7.0)        = 19,
-    iPadAir2          NS_ENUM_AVAILABLE_IOS(8.1)        = 20,
-    iPadMini3         NS_ENUM_AVAILABLE_IOS(8.1)        = 21,
-    iPadMini4         NS_ENUM_AVAILABLE_IOS(9.0)        = 22,
-    iPadPro12Dot9Inch NS_ENUM_AVAILABLE_IOS(9.1)        = 23,
-    iPadPro9Dot7Inch  NS_ENUM_AVAILABLE_IOS(9.3)        = 24,
+    iPad1             = 13,
+    iPad2             = 14,
+    iPadMini          = 15,
+    iPad3             = 16,
+    iPad4             = 17,
+    iPadAir           = 18,
+    iPadMini2         = 19,
+    iPadAir2          = 20,
+    iPadMini3         = 21,
+    iPadMini4         = 22,
+    iPadPro12Dot9Inch = 23,
+    iPadPro9Dot7Inch  = 24,
     
-    iPodTouch1Gen     NS_ENUM_DEPRECATED_IOS(1.1, 4.0)  = 25,
-    iPodTouch2Gen     NS_ENUM_DEPRECATED_IOS(2.1, 5.0)  = 26,
-    iPodTouch3Gen     NS_ENUM_DEPRECATED_IOS(3.1, 6.0)  = 27,
-    iPodTouch4Gen     NS_ENUM_DEPRECATED_IOS(4.1, 7.0)  = 28,
-    iPodTouch5Gen     NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 29,
-    iPodTouch6Gen     NS_ENUM_AVAILABLE_IOS(8.4)        = 30,
+    iPodTouch1Gen     = 25,
+    iPodTouch2Gen     = 26,
+    iPodTouch3Gen     = 27,
+    iPodTouch4Gen     = 28,
+    iPodTouch5Gen     = 29,
+    iPodTouch6Gen     = 30,
     
-    Simulator                                           = 31,
+    Simulator         =  0
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
-    [iPhone]            = @"iPhone",
-    [iPhone3G]          = @"iPhone 3G",
-    [iPhone3GS]         = @"iPhone 3GS",
     [iPhone4]           = @"iPhone 4",
     [iPhone4S]          = @"iPhone 4S",
     [iPhone5]           = @"iPhone 5",
@@ -87,26 +79,22 @@ static NSString *DeviceVersionNames[] = {
     
     [Simulator]         = @"Simulator"
 };
-#pragma clang diagnostic pop
 
-typedef NS_ENUM(NSInteger, DeviceSize) {
-    UnknownSize                                       = 0,
-    Screen3Dot5inch NS_ENUM_DEPRECATED_IOS(1.0, 10.0) = 1,
-    Screen4inch     NS_ENUM_AVAILABLE_IOS(6.0)        = 2,
-    Screen4Dot7inch NS_ENUM_AVAILABLE_IOS(8.0)        = 3,
-    Screen5Dot5inch NS_ENUM_AVAILABLE_IOS(8.0)        = 4,
+typedef NS_ENUM(NSInteger, DeviceSize){
+    UnknownSize     = 0,
+    Screen3Dot5inch = 1,
+    Screen4inch     = 2,
+    Screen4Dot7inch = 3,
+    Screen5Dot5inch = 4
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceSizeNames[] = {
     [UnknownSize]     = @"Unknown Size",
     [Screen3Dot5inch] = @"3.5 inch",
     [Screen4inch]     = @"4 inch",
     [Screen4Dot7inch] = @"4.7 inch",
-    [Screen5Dot5inch] = @"5.5 inch",
+    [Screen5Dot5inch] = @"5.5 inch"
 };
-#pragma clang diagnostic pop
 
 @interface SDiOSVersion : NSObject
 

--- a/SDVersion/SDtvOSVersion/SDtvOSVersion.h
+++ b/SDVersion/SDtvOSVersion/SDtvOSVersion.h
@@ -11,9 +11,8 @@
 #import <sys/utsname.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleTV4  NS_ENUM_AVAILABLE_IOS(9.0) = 1,
-    
-    Simulator                            = 0
+    AppleTV4          = 1,
+    Simulator         = 0
 };
 
 static NSString *DeviceVersionNames[] = {

--- a/SDVersion/SDwatchOSVersion/SDwatchOSVersion.h
+++ b/SDVersion/SDwatchOSVersion/SDwatchOSVersion.h
@@ -9,30 +9,27 @@
 #import <WatchKit/WatchKit.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    
-    AppleWatch38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
-    AppleWatch42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
-    
-    Simulator      = 0,
+    AppleWatch38mm = 1,
+    AppleWatch42mm = 2,
+    Simulator      = 0
 };
 
 static NSString *DeviceVersionNames[] = {
     [AppleWatch38mm] = @"Apple Watch 38mm",
     [AppleWatch42mm] = @"Apple Watch 42mm",
-    [Simulator]      = @"Simulator",
+    [Simulator]      = @"Simulator"
 };
 
-typedef NS_ENUM(NSInteger, DeviceSize) {
+typedef NS_ENUM(NSInteger, DeviceSize){
     UnknownSize = 0,
-    
-    Screen38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
-    Screen42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
+    Screen38mm  = 1,
+    Screen42mm  = 2
 };
 
 static NSString *DeviceSizeNames[] = {
     [UnknownSize] = @"Unknown Size",
     [Screen38mm]  = @"38mm",
-    [Screen42mm]  = @"42mm",
+    [Screen42mm]  = @"42mm"
 };
 
 @interface SDwatchOSVersion : NSObject


### PR DESCRIPTION
After further testing this seems like a bad decision. The fundamental purpose of the library is to target any device/screen size/os version. One of the main use cases is targeting redundant versions of these and throwing unwanted warnings would surely have no purpose here. Reverting this for now on master, as well as CocoaPods.

Reverts sebyddd/SDVersion#54