### PR TITLE
Add additional warning silencing

### DIFF
--- a/SDVersion-Demo/SDVersion/SDiOSVersion.m
+++ b/SDVersion-Demo/SDVersion/SDiOSVersion.m
@@ -14,6 +14,8 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{
                               //iPhones
                               @"iPhone3,1" : @(iPhone4),
@@ -76,6 +78,7 @@
                               @"iPod4,1" : @(iPodTouch4Gen),
                               @"iPod5,1" : @(iPodTouch5Gen),
                               @"iPod7,1" : @(iPodTouch6Gen)};
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;

--- a/SDVersion/SDiOSVersion/SDiOSVersion.m
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.m
@@ -14,6 +14,8 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{
                               //iPhones
                               @"iPhone3,1" : @(iPhone4),
@@ -68,7 +70,7 @@
                               @"iPad6,4" : @(iPadPro9Dot7Inch),
                               @"iPad6,7" : @(iPadPro12Dot9Inch),
                               @"iPad6,8" : @(iPadPro12Dot9Inch),
-                              
+
                               //iPods
                               @"iPod1,1" : @(iPodTouch1Gen),
                               @"iPod2,1" : @(iPodTouch2Gen),
@@ -76,6 +78,7 @@
                               @"iPod4,1" : @(iPodTouch4Gen),
                               @"iPod5,1" : @(iPodTouch5Gen),
                               @"iPod7,1" : @(iPodTouch6Gen)};
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;


### PR DESCRIPTION
This should fix the warnings found in #55. This will only fix warnings from building SDVersion. If you’re using old identifiers in code that can’t run on those devices anymore (e.g. if you’re using the `iPhone3G` enum on an app that runs on iOS 10 only), you’ll need to silence them like this:

```Objective-C
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wdeprecated-declarations"
// The code that uses old iOS devices
#pragma clang diagnostic pop
```

If there are a lot of people who use deprecated identifiers, we could explore creating a build flag that would do something like this:

```Objective-C
#if SDVERSION_DISABLE_DEPRECATIONS
#define NS_ENUM_AVAILABLE_IOS(x) // no-op
#define NS_ENUM_DEPRECATED_IOS(x, y) // no-op
#endif
```

But since SDVersion had already removed old devices, I _think_ people are mostly using it to get information about the _current_ device. If that’s all you’re doing, this PR should silence any warnings you’ll get while building.