### PR TITLE
Re-add availability info, with silenced warnings.

### DIFF
--- a/SDVersion-Demo/SDVersion/SDiOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDiOSVersion.h
@@ -11,42 +11,44 @@
 #import <sys/utsname.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion){
-    iPhone4           = 3,
-    iPhone4S          = 4,
-    iPhone5           = 5,
-    iPhone5C          = 6,
-    iPhone5S          = 7,
-    iPhone6           = 8,
-    iPhone6Plus       = 9,
-    iPhone6S          = 10,
-    iPhone6SPlus      = 11,
-    iPhone7           = 12,
-    iPhone7Plus       = 13,
-    iPhoneSE          = 14,
+    iPhone4           NS_ENUM_DEPRECATED_IOS(4.0, 8.0)  =  3,
+    iPhone4S          NS_ENUM_DEPRECATED_IOS(5.0, 10.0) =  4,
+    iPhone5           NS_ENUM_AVAILABLE_IOS(6.0)        =  5,
+    iPhone5C          NS_ENUM_AVAILABLE_IOS(7.0)        =  6,
+    iPhone5S          NS_ENUM_AVAILABLE_IOS(7.0)        =  7,
+    iPhone6           NS_ENUM_AVAILABLE_IOS(8.0)        =  8,
+    iPhone6Plus       NS_ENUM_AVAILABLE_IOS(8.0)        =  9,
+    iPhone6S          NS_ENUM_AVAILABLE_IOS(9.0)        = 10,
+    iPhone6SPlus      NS_ENUM_AVAILABLE_IOS(9.0)        = 11,
+    iPhone7           NS_ENUM_AVAILABLE_IOS(10.0)       = 12,
+    iPhone7Plus       NS_ENUM_AVAILABLE_IOS(10.0)       = 13,
+    iPhoneSE          NS_ENUM_AVAILABLE_IOS(9.3)        = 14,
     
-    iPad1             = 15,
-    iPad2             = 16,
-    iPadMini          = 17,
-    iPad3             = 18,
-    iPad4             = 19,
-    iPadAir           = 20,
-    iPadMini2         = 21,
-    iPadAir2          = 22,
-    iPadMini3         = 23,
-    iPadMini4         = 24,
-    iPadPro12Dot9Inch = 25,
-    iPadPro9Dot7Inch  = 26,
+    iPad1             NS_ENUM_DEPRECATED_IOS(3.2, 6.0)  = 15,
+    iPad2             NS_ENUM_DEPRECATED_IOS(4.3, 10.0) = 16,
+    iPadMini          NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 17,
+    iPad3             NS_ENUM_DEPRECATED_IOS(5.1, 10.0) = 18,
+    iPad4             NS_ENUM_AVAILABLE_IOS(6.0)        = 19,
+    iPadAir           NS_ENUM_AVAILABLE_IOS(7.0)        = 20,
+    iPadMini2         NS_ENUM_AVAILABLE_IOS(7.0)        = 21,
+    iPadAir2          NS_ENUM_AVAILABLE_IOS(8.1)        = 22,
+    iPadMini3         NS_ENUM_AVAILABLE_IOS(8.1)        = 23,
+    iPadMini4         NS_ENUM_AVAILABLE_IOS(9.0)        = 24,
+    iPadPro12Dot9Inch NS_ENUM_AVAILABLE_IOS(9.1)        = 25,
+    iPadPro9Dot7Inch  NS_ENUM_AVAILABLE_IOS(9.3)        = 26,
     
-    iPodTouch1Gen     = 27,
-    iPodTouch2Gen     = 28,
-    iPodTouch3Gen     = 29,
-    iPodTouch4Gen     = 30,
-    iPodTouch5Gen     = 31,
-    iPodTouch6Gen     = 32,
+    iPodTouch1Gen     NS_ENUM_DEPRECATED_IOS(1.1, 4.0)  = 27,
+    iPodTouch2Gen     NS_ENUM_DEPRECATED_IOS(2.1, 5.0)  = 28,
+    iPodTouch3Gen     NS_ENUM_DEPRECATED_IOS(3.1, 6.0)  = 29,
+    iPodTouch4Gen     NS_ENUM_DEPRECATED_IOS(4.1, 7.0)  = 30,
+    iPodTouch5Gen     NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 31,
+    iPodTouch6Gen     NS_ENUM_AVAILABLE_IOS(8.4)        = 32,
     
-    Simulator         =  0
+    Simulator                                           = 0,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [iPhone4]           = @"iPhone 4",
     [iPhone4S]          = @"iPhone 4S",
@@ -83,22 +85,26 @@ static NSString *DeviceVersionNames[] = {
 
     [Simulator]         = @"Simulator"
 };
+#pragma clang diagnostic pop
 
-typedef NS_ENUM(NSInteger, DeviceSize){
-    UnknownSize     = 0,
-    Screen3Dot5inch = 1,
-    Screen4inch     = 2,
-    Screen4Dot7inch = 3,
-    Screen5Dot5inch = 4
+typedef NS_ENUM(NSInteger, DeviceSize) {
+    UnknownSize                                       = 0,
+    Screen3Dot5inch NS_ENUM_DEPRECATED_IOS(1.0, 10.0) = 1,
+    Screen4inch     NS_ENUM_AVAILABLE_IOS(6.0)        = 2,
+    Screen4Dot7inch NS_ENUM_AVAILABLE_IOS(8.0)        = 3,
+    Screen5Dot5inch NS_ENUM_AVAILABLE_IOS(8.0)        = 4,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceSizeNames[] = {
     [UnknownSize]     = @"Unknown Size",
     [Screen3Dot5inch] = @"3.5 inch",
     [Screen4inch]     = @"4 inch",
     [Screen4Dot7inch] = @"4.7 inch",
-    [Screen5Dot5inch] = @"5.5 inch"
+    [Screen5Dot5inch] = @"5.5 inch",
 };
+#pragma clang diagnostic pop
 
 @interface SDiOSVersion : NSObject
 

--- a/SDVersion-Demo/SDVersion/SDiOSVersion.m
+++ b/SDVersion-Demo/SDVersion/SDiOSVersion.m
@@ -14,8 +14,13 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{
                               //iPhones
+                              @"iPhone1,1" : @(iPhone),
+                              @"iPhone1,2" : @(iPhone3G),
+                              @"iPhone2,1" : @(iPhone3GS),
                               @"iPhone3,1" : @(iPhone4),
                               @"iPhone3,2" : @(iPhone4),
                               @"iPhone3,3" : @(iPhone4),
@@ -76,6 +81,7 @@
                               @"iPod4,1" : @(iPodTouch4Gen),
                               @"iPod5,1" : @(iPodTouch5Gen),
                               @"iPod7,1" : @(iPodTouch6Gen)};
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;
@@ -92,6 +98,8 @@
     return version;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (DeviceSize)resolutionSize
 {
     CGFloat screenHeight = 0;
@@ -113,7 +121,10 @@
     } else
         return UnknownSize;
 }
+#pragma clang diagnostic pop
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (DeviceSize)deviceSize
 {
     DeviceSize deviceSize = [self resolutionSize];
@@ -123,6 +134,7 @@
     
     return deviceSize;
 }
+#pragma clang diagnostic pop
 
 + (NSString*)deviceName
 {
@@ -139,6 +151,8 @@
 #define IS_ZOOMED_IPHONE_6 (MAX([[UIScreen mainScreen] bounds].size.height, [[UIScreen mainScreen] bounds].size.width) == 568.0 && [UIScreen mainScreen].nativeScale > [UIScreen mainScreen].scale)
 #define IS_ZOOMED_IPHONE_6_PLUS (MAX([[UIScreen mainScreen] bounds].size.height, [[UIScreen mainScreen] bounds].size.width) == 667.0 && [UIScreen mainScreen].nativeScale < [UIScreen mainScreen].scale)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (BOOL)isZoomed {
     
     if ([self resolutionSize] == Screen4Dot7inch && [UIScreen mainScreen].nativeScale > [UIScreen mainScreen].scale) {
@@ -149,5 +163,6 @@
     
     return NO;
 }
+#pragma clang diagnostic pop
 
 @end

--- a/SDVersion-Demo/SDVersion/SDiOSVersion.m
+++ b/SDVersion-Demo/SDVersion/SDiOSVersion.m
@@ -18,9 +18,6 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{
                               //iPhones
-                              @"iPhone1,1" : @(iPhone),
-                              @"iPhone1,2" : @(iPhone3G),
-                              @"iPhone2,1" : @(iPhone3GS),
                               @"iPhone3,1" : @(iPhone4),
                               @"iPhone3,2" : @(iPhone4),
                               @"iPhone3,3" : @(iPhone4),

--- a/SDVersion-Demo/SDVersion/SDtvOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDtvOSVersion.h
@@ -16,10 +16,13 @@ typedef NS_ENUM(NSInteger, DeviceVersion) {
     Simulator                            = 0
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [AppleTV4]          = @"Apple TV (4th Generation)",
     [Simulator]         = @"Simulator"
 };
+#pragma clang diagnostic pop
 
 @interface SDtvOSVersion : NSObject
 

--- a/SDVersion-Demo/SDVersion/SDtvOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDtvOSVersion.h
@@ -11,14 +11,16 @@
 #import <sys/utsname.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleTV4          = 1,
-    Simulator         = 0
+    AppleTV4  NS_ENUM_AVAILABLE_IOS(9.0) = 1,
+    
+    Simulator                            = 0
 };
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [AppleTV4]          = @"Apple TV (4th Generation)",
+    
     [Simulator]         = @"Simulator"
 };
 #pragma clang diagnostic pop

--- a/SDVersion-Demo/SDVersion/SDtvOSVersion.m
+++ b/SDVersion-Demo/SDVersion/SDtvOSVersion.m
@@ -14,7 +14,10 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{ @"AppleTV5,3" : @(AppleTV4) };
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;

--- a/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
@@ -9,9 +9,11 @@
 #import <WatchKit/WatchKit.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleWatch38mm = 1,
-    AppleWatch42mm = 2,
-    Simulator      = 0
+    
+    AppleWatch38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
+    AppleWatch42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
+    
+    Simulator      = 0,
 };
 
 #pragma clang diagnostic push
@@ -19,14 +21,15 @@ typedef NS_ENUM(NSInteger, DeviceVersion) {
 static NSString *DeviceVersionNames[] = {
     [AppleWatch38mm] = @"Apple Watch 38mm",
     [AppleWatch42mm] = @"Apple Watch 42mm",
-    [Simulator]      = @"Simulator"
+    [Simulator]      = @"Simulator",
 };
 #pragma clang diagnostic pop
 
-typedef NS_ENUM(NSInteger, DeviceSize){
+typedef NS_ENUM(NSInteger, DeviceSize) {
     UnknownSize = 0,
-    Screen38mm  = 1,
-    Screen42mm  = 2
+    
+    Screen38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
+    Screen42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
 };
 
 #pragma clang diagnostic push
@@ -34,7 +37,7 @@ typedef NS_ENUM(NSInteger, DeviceSize){
 static NSString *DeviceSizeNames[] = {
     [UnknownSize] = @"Unknown Size",
     [Screen38mm]  = @"38mm",
-    [Screen42mm]  = @"42mm"
+    [Screen42mm]  = @"42mm",
 };
 #pragma clang diagnostic pop
 

--- a/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
+++ b/SDVersion-Demo/SDVersion/SDwatchOSVersion.h
@@ -16,11 +16,14 @@ typedef NS_ENUM(NSInteger, DeviceVersion) {
     Simulator      = 0,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [AppleWatch38mm] = @"Apple Watch 38mm",
     [AppleWatch42mm] = @"Apple Watch 42mm",
     [Simulator]      = @"Simulator",
 };
+#pragma clang diagnostic pop
 
 typedef NS_ENUM(NSInteger, DeviceSize) {
     UnknownSize = 0,
@@ -29,11 +32,14 @@ typedef NS_ENUM(NSInteger, DeviceSize) {
     Screen42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceSizeNames[] = {
     [UnknownSize] = @"Unknown Size",
     [Screen38mm]  = @"38mm",
     [Screen42mm]  = @"42mm",
 };
+#pragma clang diagnostic pop
 
 @interface SDwatchOSVersion : NSObject
 

--- a/SDVersion-Demo/SDVersion/SDwatchOSVersion.m
+++ b/SDVersion-Demo/SDVersion/SDwatchOSVersion.m
@@ -16,8 +16,11 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{ @"Watch1,1" : @(AppleWatch38mm),
                                @"Watch1,2" : @(AppleWatch42mm) };
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;
@@ -34,6 +37,8 @@
     return version;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (DeviceSize)deviceSize
 {
     CGFloat screenHeight = CGRectGetHeight([WKInterfaceDevice currentDevice].screenBounds);
@@ -46,6 +51,7 @@
         return UnknownSize;
     }
 }
+#pragma clang diagnostic pop
 
 + (NSString*)deviceName
 {

--- a/SDVersion/SDiOSVersion/SDiOSVersion.h
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.h
@@ -11,42 +11,44 @@
 #import <sys/utsname.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion){
-    iPhone4           = 3,
-    iPhone4S          = 4,
-    iPhone5           = 5,
-    iPhone5C          = 6,
-    iPhone5S          = 7,
-    iPhone6           = 8,
-    iPhone6Plus       = 9,
-    iPhone6S          = 10,
-    iPhone6SPlus      = 11,
-    iPhone7           = 12,
-    iPhone7Plus       = 13,
-    iPhoneSE          = 14,
+    iPhone4           NS_ENUM_DEPRECATED_IOS(4.0, 8.0)  =  3,
+    iPhone4S          NS_ENUM_DEPRECATED_IOS(5.0, 10.0) =  4,
+    iPhone5           NS_ENUM_AVAILABLE_IOS(6.0)        =  5,
+    iPhone5C          NS_ENUM_AVAILABLE_IOS(7.0)        =  6,
+    iPhone5S          NS_ENUM_AVAILABLE_IOS(7.0)        =  7,
+    iPhone6           NS_ENUM_AVAILABLE_IOS(8.0)        =  8,
+    iPhone6Plus       NS_ENUM_AVAILABLE_IOS(8.0)        =  9,
+    iPhone6S          NS_ENUM_AVAILABLE_IOS(9.0)        = 10,
+    iPhone6SPlus      NS_ENUM_AVAILABLE_IOS(9.0)        = 11,
+    iPhone7           NS_ENUM_AVAILABLE_IOS(10.0)       = 12,
+    iPhone7Plus       NS_ENUM_AVAILABLE_IOS(10.0)       = 13,
+    iPhoneSE          NS_ENUM_AVAILABLE_IOS(9.3)        = 14,
     
-    iPad1             = 15,
-    iPad2             = 16,
-    iPadMini          = 17,
-    iPad3             = 18,
-    iPad4             = 19,
-    iPadAir           = 20,
-    iPadMini2         = 21,
-    iPadAir2          = 22,
-    iPadMini3         = 23,
-    iPadMini4         = 24,
-    iPadPro12Dot9Inch = 25,
-    iPadPro9Dot7Inch  = 26,
+    iPad1             NS_ENUM_DEPRECATED_IOS(3.2, 6.0)  = 15,
+    iPad2             NS_ENUM_DEPRECATED_IOS(4.3, 10.0) = 16,
+    iPadMini          NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 17,
+    iPad3             NS_ENUM_DEPRECATED_IOS(5.1, 10.0) = 18,
+    iPad4             NS_ENUM_AVAILABLE_IOS(6.0)        = 19,
+    iPadAir           NS_ENUM_AVAILABLE_IOS(7.0)        = 20,
+    iPadMini2         NS_ENUM_AVAILABLE_IOS(7.0)        = 21,
+    iPadAir2          NS_ENUM_AVAILABLE_IOS(8.1)        = 22,
+    iPadMini3         NS_ENUM_AVAILABLE_IOS(8.1)        = 23,
+    iPadMini4         NS_ENUM_AVAILABLE_IOS(9.0)        = 24,
+    iPadPro12Dot9Inch NS_ENUM_AVAILABLE_IOS(9.1)        = 25,
+    iPadPro9Dot7Inch  NS_ENUM_AVAILABLE_IOS(9.3)        = 26,
     
-    iPodTouch1Gen     = 27,
-    iPodTouch2Gen     = 28,
-    iPodTouch3Gen     = 29,
-    iPodTouch4Gen     = 30,
-    iPodTouch5Gen     = 31,
-    iPodTouch6Gen     = 32,
+    iPodTouch1Gen     NS_ENUM_DEPRECATED_IOS(1.1, 4.0)  = 27,
+    iPodTouch2Gen     NS_ENUM_DEPRECATED_IOS(2.1, 5.0)  = 28,
+    iPodTouch3Gen     NS_ENUM_DEPRECATED_IOS(3.1, 6.0)  = 29,
+    iPodTouch4Gen     NS_ENUM_DEPRECATED_IOS(4.1, 7.0)  = 30,
+    iPodTouch5Gen     NS_ENUM_DEPRECATED_IOS(6.0, 10.0) = 31,
+    iPodTouch6Gen     NS_ENUM_AVAILABLE_IOS(8.4)        = 32,
     
-    Simulator         =  0
+    Simulator                                           = 0,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [iPhone4]           = @"iPhone 4",
     [iPhone4S]          = @"iPhone 4S",
@@ -83,22 +85,26 @@ static NSString *DeviceVersionNames[] = {
 
     [Simulator]         = @"Simulator"
 };
+#pragma clang diagnostic pop
 
-typedef NS_ENUM(NSInteger, DeviceSize){
-    UnknownSize     = 0,
-    Screen3Dot5inch = 1,
-    Screen4inch     = 2,
-    Screen4Dot7inch = 3,
-    Screen5Dot5inch = 4
+typedef NS_ENUM(NSInteger, DeviceSize) {
+    UnknownSize                                       = 0,
+    Screen3Dot5inch NS_ENUM_DEPRECATED_IOS(1.0, 10.0) = 1,
+    Screen4inch     NS_ENUM_AVAILABLE_IOS(6.0)        = 2,
+    Screen4Dot7inch NS_ENUM_AVAILABLE_IOS(8.0)        = 3,
+    Screen5Dot5inch NS_ENUM_AVAILABLE_IOS(8.0)        = 4,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceSizeNames[] = {
     [UnknownSize]     = @"Unknown Size",
     [Screen3Dot5inch] = @"3.5 inch",
     [Screen4inch]     = @"4 inch",
     [Screen4Dot7inch] = @"4.7 inch",
-    [Screen5Dot5inch] = @"5.5 inch"
+    [Screen5Dot5inch] = @"5.5 inch",
 };
+#pragma clang diagnostic pop
 
 @interface SDiOSVersion : NSObject
 

--- a/SDVersion/SDiOSVersion/SDiOSVersion.m
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.m
@@ -14,8 +14,13 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{
                               //iPhones
+                              @"iPhone1,1" : @(iPhone),
+                              @"iPhone1,2" : @(iPhone3G),
+                              @"iPhone2,1" : @(iPhone3GS),
                               @"iPhone3,1" : @(iPhone4),
                               @"iPhone3,2" : @(iPhone4),
                               @"iPhone3,3" : @(iPhone4),
@@ -68,7 +73,7 @@
                               @"iPad6,4" : @(iPadPro9Dot7Inch),
                               @"iPad6,7" : @(iPadPro12Dot9Inch),
                               @"iPad6,8" : @(iPadPro12Dot9Inch),
-                              
+
                               //iPods
                               @"iPod1,1" : @(iPodTouch1Gen),
                               @"iPod2,1" : @(iPodTouch2Gen),
@@ -76,6 +81,7 @@
                               @"iPod4,1" : @(iPodTouch4Gen),
                               @"iPod5,1" : @(iPodTouch5Gen),
                               @"iPod7,1" : @(iPodTouch6Gen)};
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;
@@ -92,6 +98,8 @@
     return version;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (DeviceSize)resolutionSize
 {
     CGFloat screenHeight = 0;
@@ -113,7 +121,10 @@
     } else
         return UnknownSize;
 }
+#pragma clang diagnostic pop
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (DeviceSize)deviceSize
 {
     DeviceSize deviceSize = [self resolutionSize];
@@ -123,6 +134,7 @@
     
     return deviceSize;
 }
+#pragma clang diagnostic pop
 
 + (NSString*)deviceName
 {
@@ -139,6 +151,8 @@
 #define IS_ZOOMED_IPHONE_6 (MAX([[UIScreen mainScreen] bounds].size.height, [[UIScreen mainScreen] bounds].size.width) == 568.0 && [UIScreen mainScreen].nativeScale > [UIScreen mainScreen].scale)
 #define IS_ZOOMED_IPHONE_6_PLUS (MAX([[UIScreen mainScreen] bounds].size.height, [[UIScreen mainScreen] bounds].size.width) == 667.0 && [UIScreen mainScreen].nativeScale < [UIScreen mainScreen].scale)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (BOOL)isZoomed {
     
     if ([self resolutionSize] == Screen4Dot7inch && [UIScreen mainScreen].nativeScale > [UIScreen mainScreen].scale) {
@@ -149,5 +163,6 @@
     
     return NO;
 }
+#pragma clang diagnostic pop
 
 @end

--- a/SDVersion/SDiOSVersion/SDiOSVersion.m
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.m
@@ -18,9 +18,6 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{
                               //iPhones
-                              @"iPhone1,1" : @(iPhone),
-                              @"iPhone1,2" : @(iPhone3G),
-                              @"iPhone2,1" : @(iPhone3GS),
                               @"iPhone3,1" : @(iPhone4),
                               @"iPhone3,2" : @(iPhone4),
                               @"iPhone3,3" : @(iPhone4),

--- a/SDVersion/SDtvOSVersion/SDtvOSVersion.h
+++ b/SDVersion/SDtvOSVersion/SDtvOSVersion.h
@@ -16,10 +16,13 @@ typedef NS_ENUM(NSInteger, DeviceVersion) {
     Simulator                            = 0
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [AppleTV4]          = @"Apple TV (4th Generation)",
     [Simulator]         = @"Simulator"
 };
+#pragma clang diagnostic pop
 
 @interface SDtvOSVersion : NSObject
 

--- a/SDVersion/SDtvOSVersion/SDtvOSVersion.h
+++ b/SDVersion/SDtvOSVersion/SDtvOSVersion.h
@@ -11,14 +11,16 @@
 #import <sys/utsname.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleTV4          = 1,
-    Simulator         = 0
+    AppleTV4  NS_ENUM_AVAILABLE_IOS(9.0) = 1,
+    
+    Simulator                            = 0
 };
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [AppleTV4]          = @"Apple TV (4th Generation)",
+    
     [Simulator]         = @"Simulator"
 };
 #pragma clang diagnostic pop

--- a/SDVersion/SDtvOSVersion/SDtvOSVersion.m
+++ b/SDVersion/SDtvOSVersion/SDtvOSVersion.m
@@ -14,7 +14,10 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{ @"AppleTV5,3" : @(AppleTV4) };
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;

--- a/SDVersion/SDwatchOSVersion/SDwatchOSVersion.h
+++ b/SDVersion/SDwatchOSVersion/SDwatchOSVersion.h
@@ -9,9 +9,11 @@
 #import <WatchKit/WatchKit.h>
 
 typedef NS_ENUM(NSInteger, DeviceVersion) {
-    AppleWatch38mm = 1,
-    AppleWatch42mm = 2,
-    Simulator      = 0
+    
+    AppleWatch38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
+    AppleWatch42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
+    
+    Simulator      = 0,
 };
 
 #pragma clang diagnostic push
@@ -19,14 +21,15 @@ typedef NS_ENUM(NSInteger, DeviceVersion) {
 static NSString *DeviceVersionNames[] = {
     [AppleWatch38mm] = @"Apple Watch 38mm",
     [AppleWatch42mm] = @"Apple Watch 42mm",
-    [Simulator]      = @"Simulator"
+    [Simulator]      = @"Simulator",
 };
 #pragma clang diagnostic pop
 
-typedef NS_ENUM(NSInteger, DeviceSize){
+typedef NS_ENUM(NSInteger, DeviceSize) {
     UnknownSize = 0,
-    Screen38mm  = 1,
-    Screen42mm  = 2
+    
+    Screen38mm NS_ENUM_AVAILABLE_IOS(1.0) = 1,
+    Screen42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
 };
 
 #pragma clang diagnostic push
@@ -34,7 +37,7 @@ typedef NS_ENUM(NSInteger, DeviceSize){
 static NSString *DeviceSizeNames[] = {
     [UnknownSize] = @"Unknown Size",
     [Screen38mm]  = @"38mm",
-    [Screen42mm]  = @"42mm"
+    [Screen42mm]  = @"42mm",
 };
 #pragma clang diagnostic pop
 

--- a/SDVersion/SDwatchOSVersion/SDwatchOSVersion.h
+++ b/SDVersion/SDwatchOSVersion/SDwatchOSVersion.h
@@ -16,11 +16,14 @@ typedef NS_ENUM(NSInteger, DeviceVersion) {
     Simulator      = 0,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceVersionNames[] = {
     [AppleWatch38mm] = @"Apple Watch 38mm",
     [AppleWatch42mm] = @"Apple Watch 42mm",
     [Simulator]      = @"Simulator",
 };
+#pragma clang diagnostic pop
 
 typedef NS_ENUM(NSInteger, DeviceSize) {
     UnknownSize = 0,
@@ -29,11 +32,14 @@ typedef NS_ENUM(NSInteger, DeviceSize) {
     Screen42mm NS_ENUM_AVAILABLE_IOS(1.0) = 2,
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static NSString *DeviceSizeNames[] = {
     [UnknownSize] = @"Unknown Size",
     [Screen38mm]  = @"38mm",
     [Screen42mm]  = @"42mm",
 };
+#pragma clang diagnostic pop
 
 @interface SDwatchOSVersion : NSObject
 

--- a/SDVersion/SDwatchOSVersion/SDwatchOSVersion.m
+++ b/SDVersion/SDwatchOSVersion/SDwatchOSVersion.m
@@ -16,8 +16,11 @@
     static NSDictionary *deviceNamesByCode = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         deviceNamesByCode = @{ @"Watch1,1" : @(AppleWatch38mm),
                                @"Watch1,2" : @(AppleWatch42mm) };
+#pragma clang diagnostic pop
     });
     
     return deviceNamesByCode;
@@ -34,6 +37,8 @@
     return version;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (DeviceSize)deviceSize
 {
     CGFloat screenHeight = CGRectGetHeight([WKInterfaceDevice currentDevice].screenBounds);
@@ -46,6 +51,7 @@
         return UnknownSize;
     }
 }
+#pragma clang diagnostic pop
 
 + (NSString*)deviceName
 {
@@ -58,6 +64,5 @@
     
     return code;
 }
-
 
 @end


### PR DESCRIPTION
This PR re-adds the availability info, with all warnings silenced in apps that use SDVersion.
