### PR TITLE
More robust isZoomed check

### DIFF
--- a/SDVersion/SDiOSVersion/SDiOSVersion.m
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.m
@@ -134,8 +134,9 @@
         return Screen5Dot5inch;
     } else if (screenHeight == 812) {
         return Screen5Dot8inch;
-    } else
+    } else {
         return UnknownSize;
+    }
 }
 
 + (DeviceSize)deviceSize
@@ -219,7 +220,7 @@
 {
     if ([self resolutionSize] == Screen4inch && [UIScreen mainScreen].nativeScale > 2) {
         return YES;
-    }else if ([self resolutionSize] == Screen4Dot7inch && [UIScreen mainScreen].scale == 3){
+    } else if ([self resolutionSize] == Screen4Dot7inch && [UIScreen mainScreen].scale != [UIScreen mainScreen].nativeScale) {
         return YES;
     }
     


### PR DESCRIPTION
On iPhone X in compatibility mode, iOS reports `UIScreen.main.bounds.size` as 375x667 (which means iPhone X in compatibility mode is effectively a 4.7" device).

However, when calling `SDiOSVersion.deviceSize()`, the `isZoomed` check improperly returns `true`, so instead of getting `.Screen4Dot7inch`, I get `.Screen5Dot5inch`.

If someone could help verify this logic is correct (or at least more correct than the current one), I'd really appreciate it!

---

A couple scenarios I collected:

iPhone 6:
- nativeScale: 2.0
- scale: 2.0

iPhone 7 Plus:
- nativeScale: 3.0
- scale: 3.0

iPhone X:
- nativeScale: 3.0
- scale: 3.0
