### PR TITLE
Use the simulator identifier from NSProcessInfo on simulated OSes.

### DIFF
--- a/SDVersion/SDiOSVersion/SDiOSVersion.m
+++ b/SDVersion/SDiOSVersion/SDiOSVersion.m
@@ -105,9 +105,18 @@
 
 + (DeviceVersion)deviceVersion
 {
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    NSString *code = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+    NSString *code = nil;
+    
+#if TARGET_OS_SIMULATOR
+    code = NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
+#endif // TARGET_OS_SIMULATOR
+    
+    if (code == nil) {
+        struct utsname systemInfo;
+        uname(&systemInfo);
+        code = [NSString stringWithCString:systemInfo.machine
+                                  encoding:NSUTF8StringEncoding];
+    }
     
     DeviceVersion version = (DeviceVersion)[[self.deviceNamesByCode objectForKey:code] integerValue];
     

--- a/SDVersion/SDtvOSVersion/SDtvOSVersion.m
+++ b/SDVersion/SDtvOSVersion/SDtvOSVersion.m
@@ -29,10 +29,19 @@
 
 + (DeviceVersion)deviceVersion
 {
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    NSString *code = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+    NSString *code = nil;
     
+#if TARGET_OS_SIMULATOR
+    code = NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
+#endif // TARGET_OS_SIMULATOR
+    
+    if (code == nil) {
+        struct utsname systemInfo;
+        uname(&systemInfo);
+        code = [NSString stringWithCString:systemInfo.machine
+                                  encoding:NSUTF8StringEncoding];
+    }
+
     DeviceVersion version = (DeviceVersion)[[self.deviceNamesByCode objectForKey:code] integerValue];
     
     return version;

--- a/SDVersion/SDwatchOSVersion/SDwatchOSVersion.m
+++ b/SDVersion/SDwatchOSVersion/SDwatchOSVersion.m
@@ -34,10 +34,19 @@
 
 + (DeviceVersion)deviceVersion
 {
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    NSString *code = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+    NSString *code = nil;
     
+#if TARGET_OS_SIMULATOR
+    code = NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
+#endif // TARGET_OS_SIMULATOR
+    
+    if (code == nil) {
+        struct utsname systemInfo;
+        uname(&systemInfo);
+        code = [NSString stringWithCString:systemInfo.machine
+                                  encoding:NSUTF8StringEncoding];
+    }
+
     DeviceVersion version = (DeviceVersion)[[self.deviceNamesByCode objectForKey:code] integerValue];
     
     return version;


### PR DESCRIPTION
This PR fixes #79 by returning the simulated device model from `NSProcessInfo`, so that if you’re using SDVersion on the simulator you can simulate device-specific code for testing.